### PR TITLE
Fix GitHub link in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ toothpick {
     val versionTag = System.getenv("BUILD_NUMBER")
         ?: "\"${gitCmd("rev-parse", "--short", "HEAD").output}\""
     forkVersion = "git-$forkName-$versionTag"
-    forkUrl = "https://github.com/Technove/Airplane-Lite"
+    forkUrl = "https://github.com/Technove/AirplaneLite"
 
     minecraftVersion = "1.16.5"
     nmsPackage = "1_16_R3"


### PR DESCRIPTION
Link incorrectly points to https://github.com/Technove/Airplane-Lite